### PR TITLE
🛂 fixed usage example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ package main
 
 import (
     "fmt"
-	"github.com/tiktoken-go/tokenizer"
+    "github.com/tiktoken-go/tokenizer"
 )
 
-func main {
+func main() {
     enc, err := tokenizer.Get(tokenizer.Cl100kBase)
     if err != nil {
         panic("oh oh")
     }
 
     // this should print a list of token ids
-    ids, token, _ := enc.Encode("supercalifragilistic")
+    ids, _, _ := enc.Encode("supercalifragilistic")
     fmt.Println(ids)
 
     // this should print the original string back


### PR DESCRIPTION
- Indents in the import block were not consistent
- `()` was missing in the main function
- `token` was unused

The last 2 points, prevented the example from compiling.