### PR TITLE
Update alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ them at runtime.
 
 Here is a list of other libraries that do something similar.
 
-- [https://github.com/sugarme/tokenizer](https://github.com/sugarme/tokenizer)
-- [https://github.com/pandodao/tokenizer-go](https://github.com/pandodao/tokenizer-go)
+- [https://github.com/sugarme/tokenizer](https://github.com/sugarme/tokenizer) (A different tokenizer algorithm than OpenAI's)
+- [https://github.com/pandodao/tokenizer-go](https://github.com/pandodao/tokenizer-go) (deprecated, calls into JavaScript)
+- [https://github.com/pkoukk/tiktoken-go](https://github.com/pkoukk/tiktoken-go)
 
 


### PR DESCRIPTION
Hi :wave: , thanks for open sourcing the tokenizer :+1: 

I noticed that the listed alternatives have some gotchas and thought it's useful to mention them directly. This way people can directly stay on your repo page without having to find those out first.

I also added another alternative, it's the one listed as alternative in the now deprecated library that you listed. It has one interesting feature that you could take some inspiration from: By default it downloads the OpenAI vocabulary, but optionally you can download it via a separate module. This way you can choose which way you prefer, and the fixed/required embedding doesn't have to be mentioned as caveat in the README.