### PR TITLE
Add support of chatgpt-4o-latest model

### DIFF
--- a/tokenizer.go
+++ b/tokenizer.go
@@ -74,8 +74,8 @@ package tokenizer
 //}
 
 import (
-	"strings"
 	"errors"
+	"strings"
 
 	"github.com/tiktoken-go/tokenizer/codec"
 )
@@ -144,11 +144,14 @@ const (
 )
 
 var modelPrefixToEncoding map[Model]Encoding = map[Model]Encoding{
-	"o1-":              O200kBase,
-	"gpt-4o-":          O200kBase,
-	"gpt-4-":           Cl100kBase,
-	"gpt-3.5-turbo-":   Cl100kBase,
-	"gpt-35-turbo-":    Cl100kBase,
+	"o1-": O200kBase,
+	// chat
+	"chatgpt-4o-":    O200kBase,
+	"gpt-4o-":        O200kBase,
+	"gpt-4-":         Cl100kBase,
+	"gpt-3.5-turbo-": Cl100kBase,
+	"gpt-35-turbo-":  Cl100kBase,
+	// fine-tuned
 	"ft:gpt-4":         Cl100kBase,
 	"ft:gpt-3.5-turbo": Cl100kBase,
 	"ft:davinci-002":   Cl100kBase,


### PR DESCRIPTION
This PR adds support of [chatgpt-4o-latest](https://platform.openai.com/docs/models#current-model-aliases) model alias. 

_Sorry for re-order of imports. That was done by my VS code automatically._